### PR TITLE
Add process.exit(0) to end of each command

### DIFF
--- a/src/commands/CacheClear.ts
+++ b/src/commands/CacheClear.ts
@@ -31,5 +31,7 @@ export class CacheClear extends CommandRunner {
     console.log('Cache was successfully cleared');
 
     await this.dataSource.destroy();
+
+    process.exit(0);
   }
 }

--- a/src/commands/MigrationCreate.ts
+++ b/src/commands/MigrationCreate.ts
@@ -44,6 +44,8 @@ export class MigrationCreate extends CommandRunner {
     await writeFile(filePath, fileContent);
 
     console.log(`Migration ${filePath} has been created successfully.`);
+
+    process.exit(0);
   }
 
   @Option({

--- a/src/commands/MigrationGenerate.ts
+++ b/src/commands/MigrationGenerate.ts
@@ -99,6 +99,7 @@ export class MigrationGenerate extends CommandRunner {
       });
     } finally {
       await this.dataSource.destroy();
+      process.exit(0);
     }
 
     if (!upQueries.length) {

--- a/src/commands/MigrationRevert.ts
+++ b/src/commands/MigrationRevert.ts
@@ -45,6 +45,8 @@ export class MigrationRevert extends CommandRunner {
     });
 
     await this.dataSource.destroy();
+
+    process.exit(0);
   }
 
   @Option({

--- a/src/commands/MigrationRun.ts
+++ b/src/commands/MigrationRun.ts
@@ -45,6 +45,8 @@ export class MigrationRun extends CommandRunner {
     });
 
     await this.dataSource.destroy();
+
+    process.exit(0);
   }
 
   @Option({

--- a/src/commands/MigrationShow.ts
+++ b/src/commands/MigrationShow.ts
@@ -38,5 +38,7 @@ export class MigrationShow extends CommandRunner {
     await this.dataSource.showMigrations();
 
     await this.dataSource.destroy();
+
+    process.exit(0);
   }
 }

--- a/src/commands/Query.ts
+++ b/src/commands/Query.ts
@@ -33,5 +33,7 @@ export class Query extends CommandRunner {
 
     await queryRunner.release();
     await this.dataSource.destroy();
+
+    process.exit(0);
   }
 }

--- a/src/commands/SchemaDrop.ts
+++ b/src/commands/SchemaDrop.ts
@@ -24,5 +24,7 @@ export class SchemaDrop extends CommandRunner {
     await this.dataSource.destroy();
 
     console.log('Database schema has been successfully dropped.');
+
+    process.exit(0);
   }
 }

--- a/src/commands/SchemaLog.ts
+++ b/src/commands/SchemaLog.ts
@@ -29,7 +29,7 @@ export class SchemaLog extends CommandRunner {
         'Your schema is up to date - there are no queries to be executed by schema synchronization.',
       );
       await this.dataSource.destroy();
-      return;
+      process.exit(0);
     }
 
     const lengthSeparators = String(sqlInMemory.upQueries.length)
@@ -56,5 +56,7 @@ export class SchemaLog extends CommandRunner {
     });
 
     await this.dataSource.destroy();
+
+    process.exit(0);
   }
 }

--- a/src/commands/SchemaSync.ts
+++ b/src/commands/SchemaSync.ts
@@ -25,5 +25,7 @@ export class SchemaSync extends CommandRunner {
     await this.dataSource.destroy();
 
     console.log('Schema synchronization finished successfully.');
+
+    process.exit(0);
   }
 }

--- a/src/commands/Version.ts
+++ b/src/commands/Version.ts
@@ -44,6 +44,8 @@ export class Version extends CommandRunner {
           'or you are using locally installed TypeORM instead of global one.',
       );
     }
+
+    process.exit(0);
   }
 
   private executeCommand(command: string) {


### PR DESCRIPTION
if migration:run will not exits, so it going to stack deployment processes in CI/CD environment. So I added `process.exit(0)` to each successful end of command.

If to be truth it is not absolutely necessary, because I can archive force exiting with

```ts
await CommandFactory.run(AppModule, ['warn', 'error']).then(() =>
    process.exit(0),
  );
```

So, if you wont merge this PR in any case, it might be worth adding this idea to the readme.